### PR TITLE
anniv_client: filter null albums

### DIFF
--- a/lib/services/anniv/anniv_client.dart
+++ b/lib/services/anniv/anniv_client.dart
@@ -198,6 +198,7 @@ class AnnivClient {
     final response =
         await _client.get('/api/meta/album', queryParameters: {'id[]': albums});
     final Map<String, dynamic> responseAlbums = response.data;
+    responseAlbums.removeWhere((final _, final value) => value == null);
     return responseAlbums
         .map((final key, final value) =>
             MapEntry(key, value as Map<String, dynamic>))


### PR DESCRIPTION
If any of `albums` has no metadata, exception will be raised, preventing other successful queries.